### PR TITLE
allow trips without vehicle, but show as scheduled

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Go",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:1-1.22-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.23-bookworm",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-golang 1.22.3
+golang 1.23.2
 kubectl 1.27.7
 helm 3.13.2

--- a/deployments/charts/nextride-shortcut/templates/ingress.yaml
+++ b/deployments/charts/nextride-shortcut/templates/ingress.yaml
@@ -16,14 +16,17 @@ spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if or .Values.ingress.tls.enabled .Values.ingress.tls.extraTls }}
   tls:
-    {{- range .Values.ingress.tls }}
+    - hosts:
+        - {{ .Values.ingress.hostname }}
+      secretName: {{ .Values.ingress.hostname | quote }}
+    {{- range .Values.ingress.tls.extraTls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ default . .secretName }}
     {{- end }}
   {{- end }}
   rules:

--- a/deployments/charts/nextride-shortcut/values.yaml
+++ b/deployments/charts/nextride-shortcut/values.yaml
@@ -16,7 +16,7 @@ fullnameOverride: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: true
+  create: false
   # Automatically mount a ServiceAccount's API credentials?
   automount: true
   # Annotations to add to the service account
@@ -51,16 +51,18 @@ ingress:
   className: ""
   annotations: {}
   hostname: nextride.local
+  tls:
+    enabled: false
+    extraTls: []
+      #  - secretName: chart-example-tls
+      #    hosts:
+      #      - chart-example.local
   extraHosts:
     []
     # - host: chart-example.local
     #   paths:
     #     - path: /
     #       pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
   pathType:
 
 resources:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aztechian/nextride-shortcut
 
-go 1.22.3
+go 1.23.2
 
 require (
 	github.com/gorilla/handlers v1.5.2

--- a/internal/rtd/http.go
+++ b/internal/rtd/http.go
@@ -18,7 +18,7 @@ type Rtd struct {
 const (
 	URL_TEMPLATE = "https://nodejs-prod.rtd-denver.com/api/v2/nextride/stops/%d"
 	API_KEY      = "e7b926a1-cddb-46e7-bb27-6d134e5b5feb"
-	BROWSER      = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15"
+	BROWSER      = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15"
 )
 
 // NewRtd creates a new Rtd struct with a sensible default http.Client (10 second timeout)

--- a/internal/rtd/trip.go
+++ b/internal/rtd/trip.go
@@ -66,7 +66,7 @@ type Vehicle struct {
 }
 
 func (t *Trip) IsValid() bool {
-	return t.IsScheduled() || t.HasVehicle()
+	return t.IsScheduled() || t.IsPredicted() || t.HasVehicle()
 }
 
 func (t *Trip) IsScheduled() bool {
@@ -79,6 +79,10 @@ func (t *Trip) IsShuttleBus() bool {
 
 func (t *Trip) IsCancelled() bool {
 	return t.TripStatus == CANCELLED
+}
+
+func (t *Trip) IsPredicted() bool {
+	return t.PredictedArrivalTime != nil
 }
 
 func (t *Trip) HasVehicle() bool {

--- a/internal/rtd/trip.go
+++ b/internal/rtd/trip.go
@@ -8,6 +8,7 @@ import (
 const (
 	SCHEDULED = "SCHEDULED"
 	SHUTTLE   = "BUS SHUTTLE"
+	CANCELLED = "CANCELLED"
 	MS_TO_SEC = 1000
 )
 
@@ -65,7 +66,7 @@ type Vehicle struct {
 }
 
 func (t *Trip) IsValid() bool {
-	return (t.Vehicle != nil && t.Vehicle.ID != "") || t.PredictedArrivalTime != nil
+	return t.IsScheduled() || t.HasVehicle()
 }
 
 func (t *Trip) IsScheduled() bool {
@@ -74,6 +75,14 @@ func (t *Trip) IsScheduled() bool {
 
 func (t *Trip) IsShuttleBus() bool {
 	return t.TripStopStatus == SHUTTLE
+}
+
+func (t *Trip) IsCancelled() bool {
+	return t.TripStatus == CANCELLED
+}
+
+func (t *Trip) HasVehicle() bool {
+	return t.Vehicle != nil && t.Vehicle.ID != ""
 }
 
 func (t *Trip) GetTime() string {

--- a/internal/rtd/trip_test.go
+++ b/internal/rtd/trip_test.go
@@ -20,10 +20,11 @@ func TestTripIsValid(t *testing.T) {
 		want bool
 	}{
 		{"Default object", rtd.Trip{}, false},
-		{"No vehicle ID", rtd.Trip{Vehicle: &rtd.Vehicle{}, PredictedArrivalTime: &arrival}, true},
-		{"No predicted arrival time", rtd.Trip{Vehicle: &rtd.Vehicle{ID: vehicleId}}, true},
+		{"Scheduled with no vehicle", rtd.Trip{Vehicle: &rtd.Vehicle{}, PredictedArrivalTime: &arrival, TripStopStatus: rtd.SCHEDULED}, true},
+		{"Has vehicle, but no predicted arrival", rtd.Trip{Vehicle: &rtd.Vehicle{ID: vehicleId}}, true},
+		{"CANCELLED trip", rtd.Trip{ScheduledArrivalTime: &arrival, TripStatus: rtd.CANCELLED}, false},
 		{"Predicted arrival time, but no vehicle", rtd.Trip{PredictedArrivalTime: &arrival}, true},
-		{"Valid object", rtd.Trip{Vehicle: &rtd.Vehicle{ID: vehicleId}, PredictedArrivalTime: &arrival}, true},
+		{"Valid object", rtd.Trip{Vehicle: &rtd.Vehicle{ID: vehicleId}, PredictedArrivalTime: &arrival, TripStopStatus: rtd.SCHEDULED}, true},
 	}
 
 	for _, tt := range tests {

--- a/test/25434.json
+++ b/test/25434.json
@@ -41,8 +41,8 @@
                     "stopDropOffType": 1,
                     "stopPickupType": 0,
                     "tripId": "115032776",
-                    "tripStatus": "SCHEDULED",
-                    "tripStopStatus": "SCHEDULED"
+                    "tripStatus": "CANCELLED",
+                    "tripStopStatus": "CANCELLED"
                 },
                 {
                     "predictedArrivalTime": null,
@@ -52,8 +52,8 @@
                     "stopDropOffType": 1,
                     "stopPickupType": 0,
                     "tripId": "115032777",
-                    "tripStatus": "SCHEDULED",
-                    "tripStopStatus": "SCHEDULED"
+                    "tripStatus": "CANCELLED",
+                    "tripStopStatus": "CANCELLED"
                 },
                 {
                     "predictedArrivalTime": null,
@@ -74,8 +74,8 @@
                     "stopDropOffType": 1,
                     "stopPickupType": 0,
                     "tripId": "115032778",
-                    "tripStatus": "SCHEDULED",
-                    "tripStopStatus": "SCHEDULED"
+                    "tripStatus": "CANCELLED",
+                    "tripStopStatus": "CANCELLED"
                 },
                 {
                     "predictedArrivalTime": null,

--- a/test/34008.json
+++ b/test/34008.json
@@ -1,0 +1,180 @@
+{
+    "id": "34008",
+    "name": "Arapahoe at Village Center Station",
+    "lat": 39.600442,
+    "lng": -104.888539,
+    "childStops": [],
+    "parentStationName": "Arapahoe at Village Center Station",
+    "parentStationId": "33705",
+    "branches": [
+        {
+            "id": "E",
+            "routeColor": "#552683",
+            "routeTextColor": "#FFFFFF",
+            "routeLongName": "Union Station to RidgeGate Parkway Station",
+            "routeType": 2,
+            "mode": "RAIL",
+            "headsign": "Union Station",
+            "directionId": 0,
+            "directionName": "Northbound",
+            "stopName": "Arapahoe at Village Center Station",
+            "stopId": "34008",
+            "agencyId": "RTD",
+            "dropoffOnly": false,
+            "upcomingTrips": [
+                {
+                    "predictedArrivalTime": null,
+                    "predictedDepartureTime": null,
+                    "scheduledArrivalTime": 1730783340000,
+                    "scheduledDepartureTime": 1730783340000,
+                    "stopDropOffType": 0,
+                    "stopPickupType": 0,
+                    "tripId": "115073212",
+                    "tripStatus": "SCHEDULED",
+                    "tripStopStatus": "SCHEDULED"
+                },
+                {
+                    "predictedArrivalTime": null,
+                    "predictedDepartureTime": null,
+                    "scheduledArrivalTime": 1730785140000,
+                    "scheduledDepartureTime": 1730785140000,
+                    "stopDropOffType": 0,
+                    "stopPickupType": 0,
+                    "tripId": "115073307",
+                    "tripStatus": "SCHEDULED",
+                    "tripStopStatus": "SCHEDULED"
+                },
+                {
+                    "predictedArrivalTime": null,
+                    "predictedDepartureTime": null,
+                    "scheduledArrivalTime": 1730786940000,
+                    "scheduledDepartureTime": 1730786940000,
+                    "stopDropOffType": 0,
+                    "stopPickupType": 0,
+                    "tripId": "115073211",
+                    "tripStatus": "SCHEDULED",
+                    "tripStopStatus": "SCHEDULED"
+                },
+                {
+                    "predictedArrivalTime": null,
+                    "predictedDepartureTime": null,
+                    "scheduledArrivalTime": 1730788740000,
+                    "scheduledDepartureTime": 1730788740000,
+                    "stopDropOffType": 0,
+                    "stopPickupType": 0,
+                    "tripId": "115073308",
+                    "tripStatus": "SCHEDULED",
+                    "tripStopStatus": "SCHEDULED"
+                },
+                {
+                    "predictedArrivalTime": null,
+                    "predictedDepartureTime": null,
+                    "scheduledArrivalTime": 1730808540000,
+                    "scheduledDepartureTime": 1730808540000,
+                    "stopDropOffType": 0,
+                    "stopPickupType": 0,
+                    "tripId": "115073302",
+                    "tripStatus": "SCHEDULED",
+                    "tripStopStatus": "SCHEDULED"
+                },
+                {
+                    "predictedArrivalTime": null,
+                    "predictedDepartureTime": null,
+                    "scheduledArrivalTime": 1730810340000,
+                    "scheduledDepartureTime": 1730810340000,
+                    "stopDropOffType": 0,
+                    "stopPickupType": 0,
+                    "tripId": "115073228",
+                    "tripStatus": "SCHEDULED",
+                    "tripStopStatus": "SCHEDULED"
+                }
+            ]
+        },
+        {
+            "id": "R",
+            "routeColor": "#C4D600",
+            "routeTextColor": "#000000",
+            "routeLongName": "Lincoln Station to Peoria Station",
+            "routeType": 2,
+            "mode": "RAIL",
+            "headsign": "R Line Peoria Station",
+            "directionId": 0,
+            "directionName": "Northbound",
+            "stopName": "Arapahoe at Village Center Station",
+            "stopId": "34008",
+            "agencyId": "RTD",
+            "dropoffOnly": false,
+            "upcomingTrips": [
+                {
+                    "predictedArrivalTime": null,
+                    "predictedDepartureTime": null,
+                    "scheduledArrivalTime": 1730784060000,
+                    "scheduledDepartureTime": 1730784060000,
+                    "stopDropOffType": 0,
+                    "stopPickupType": 0,
+                    "tripId": "115075575",
+                    "tripStatus": "SCHEDULED",
+                    "tripStopStatus": "SCHEDULED"
+                },
+                {
+                    "predictedArrivalTime": null,
+                    "predictedDepartureTime": null,
+                    "scheduledArrivalTime": 1730785860000,
+                    "scheduledDepartureTime": 1730785860000,
+                    "stopDropOffType": 0,
+                    "stopPickupType": 0,
+                    "tripId": "115075574",
+                    "tripStatus": "SCHEDULED",
+                    "tripStopStatus": "SCHEDULED"
+                },
+                {
+                    "predictedArrivalTime": null,
+                    "predictedDepartureTime": null,
+                    "scheduledArrivalTime": 1730787660000,
+                    "scheduledDepartureTime": 1730787660000,
+                    "stopDropOffType": 0,
+                    "stopPickupType": 0,
+                    "tripId": "115075573",
+                    "tripStatus": "SCHEDULED",
+                    "tripStopStatus": "SCHEDULED"
+                },
+                {
+                    "predictedArrivalTime": null,
+                    "predictedDepartureTime": null,
+                    "scheduledArrivalTime": 1730809410000,
+                    "scheduledDepartureTime": 1730809410000,
+                    "stopDropOffType": 0,
+                    "stopPickupType": 0,
+                    "tripId": "115075608",
+                    "tripStatus": "SCHEDULED",
+                    "tripStopStatus": "SCHEDULED"
+                },
+                {
+                    "predictedArrivalTime": null,
+                    "predictedDepartureTime": null,
+                    "scheduledArrivalTime": 1730811060000,
+                    "scheduledDepartureTime": 1730811060000,
+                    "stopDropOffType": 0,
+                    "stopPickupType": 0,
+                    "tripId": "115075607",
+                    "tripStatus": "SCHEDULED",
+                    "tripStopStatus": "SCHEDULED"
+                },
+                {
+                    "predictedArrivalTime": null,
+                    "predictedDepartureTime": null,
+                    "scheduledArrivalTime": 1730812860000,
+                    "scheduledDepartureTime": 1730812860000,
+                    "stopDropOffType": 0,
+                    "stopPickupType": 0,
+                    "tripId": "115075587",
+                    "tripStatus": "SCHEDULED",
+                    "tripStopStatus": "SCHEDULED"
+                }
+            ]
+        }
+    ],
+    "directions": [
+        "Northbound"
+    ]
+}


### PR DESCRIPTION
- improve ingress options in chart
- add example json response without vehicle info